### PR TITLE
Add options for initial ids and timestamp

### DIFF
--- a/document.go
+++ b/document.go
@@ -19,20 +19,12 @@ func WithIdentifiers(identifiers [][]string) DocumentOption {
 
 func WithInitialTime(t time.Time) DocumentOption {
 	return func(d *Document) {
-		if len(d.history) == 0 {
-			return
-		}
-
 		d.history[0].Ts = t.UnixMilli()
 	}
 }
 
 func WithInitialIDs(cid, gid string) DocumentOption {
 	return func(d *Document) {
-		if len(d.history) == 0 {
-			return
-		}
-
 		d.history[0].Cid = cid
 		d.history[0].Gid = gid
 	}

--- a/document_test.go
+++ b/document_test.go
@@ -3,6 +3,7 @@ package pigeongo
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/google/uuid"
@@ -226,4 +227,20 @@ func TestIdentifiers(t *testing.T) {
 
 		assert.JSONEq(t, testCase.expected, string(doc.JSON()))
 	}
+}
+
+func TestOptions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	doc := NewDocument(
+		[]byte(`{"id": "123"}`),
+		WithInitialIDs("client-id", "g-id"),
+		WithInitialTime(now),
+	)
+
+	firstEntry := doc.History()[0]
+	assert.Equal(t, now.UnixMilli(), firstEntry.Ts)
+	assert.Equal(t, "client-id", firstEntry.Cid)
+	assert.Equal(t, "g-id", firstEntry.Gid)
 }


### PR DESCRIPTION
Allows you to set the IDs and timestamp for the first automatically generated message.

```go
now := time.Now()
doc := NewDocument(
[]byte(`{"id": "123"}`),
WithInitialIDs("client-id", "g-id"),
WithInitialTime(now),
)
```