### PR TITLE
ReduceHistory: do nothing, if nothing todo

### DIFF
--- a/document.go
+++ b/document.go
@@ -245,6 +245,11 @@ func (d *Document) RewindChanges(ts int64, cid string) error {
 }
 
 func (d *Document) ReduceHistory(minTs int64) error {
+	// only the initial diff
+	if len(d.history) == 1 {
+		return nil
+	}
+
 	if err := d.RewindChanges(minTs, ""); err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently the Cid, Gid and the Ts are reset if there is no history (except for the initial diff).