### PR TITLE
Bugfix: Reverse ADD with Objekt

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -39,8 +39,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           skip-cache: true
-          skip-pkg-cache: true
-          skip-build-cache: true
+          skip-save-cache: true
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/document.go
+++ b/document.go
@@ -209,7 +209,15 @@ func (d *Document) ApplyChanges(changes Changes) error {
 	// remove external _prev from changes
 	// set prev value
 	for i := range changes.Diff {
-		changes.Diff[i].Prev = workingCopy.getValue(changes.Diff[i].Path)
+		if changes.Diff[i].Op == "add" {
+			changes.Diff[i].Prev = nil
+		} else {
+			changes.Diff[i].Prev = workingCopy.getValue(changes.Diff[i].Path)
+		}
+
+		if changes.Diff[i].Op == "remove" {
+			changes.Diff[i].Value = nil
+		}
 	}
 
 	// apply
@@ -281,7 +289,7 @@ func (d *Document) ReduceHistory(minTs int64) error {
 	}
 
 	// append all newer changes to history
-	if err := workingCopy.FastForwardChanges(); err != nil {
+	if err := workingCopy.fastForwardChanges(); err != nil {
 		return err
 	}
 
@@ -299,7 +307,15 @@ func (d *Document) fastForwardChanges() error {
 
 		// set prev value, maybe changed by patch before!
 		for i := range change.Diff {
-			change.Diff[i].Prev = d.getValue(change.Diff[i].Path)
+			if change.Diff[i].Op == "add" {
+				change.Diff[i].Prev = nil
+			} else {
+				change.Diff[i].Prev = d.getValue(change.Diff[i].Path)
+			}
+
+			if change.Diff[i].Op == "remove" {
+				change.Diff[i].Value = nil
+			}
 		}
 
 		d.raw, err = patch(d.raw, change.Diff, d.identifiers)

--- a/document_test.go
+++ b/document_test.go
@@ -398,6 +398,125 @@ func TestReduceHistory(t *testing.T) {
 	assert.Equal(t, now.UnixMilli(), clone.History()[0].Ts)
 }
 
+func TestReduceHistoryWithIDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Add(-1 * time.Hour)
+	doc := NewDocument([]byte(`{"id": "123", "body":[{"id":"card1","value":"test"},{"id":"card2","value":"baa"}]}`), WithInitialIDs("client-id", "change-id"), WithInitialMid("msg-id"), WithInitialTime(now))
+
+	err := doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:    "add",
+				Path:  "/body/[card2]",
+				Value: rawMessage(`{"id":"card3","value":"tttt"}`),
+			},
+		},
+		Ts:  now.Add(10 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "dva96nqsdd",
+		Mid: "50reifj9hyt-dva96nqsdd",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:    "replace",
+				Path:  "/body/[card3]/value",
+				Value: rawMessage(`"bar"`),
+			},
+		},
+		Ts:  now.Add(40 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "hreifj9hyt",
+		Mid: "50reifj9hyt-hreifj9hyt",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:    "replace",
+				Path:  "/body/1/value",
+				Value: rawMessage(`"retert"`),
+			},
+		},
+		Ts:  now.Add(40 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "75reifj9hyt",
+		Mid: "50reifj9hyt-75reifj9hyt",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:   "remove",
+				Path: "/body/[card3]",
+			},
+		},
+		Ts:  now.Add(60 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "jdva96nqsdd",
+		Mid: "50reifj9hyt-jdva96nqsdd",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:   "remove",
+				Path: "/body/[card2]",
+			},
+		},
+		Ts:  now.Add(65 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "5gdva96nqsdd",
+		Mid: "50reifj9hyt-5gdva96nqsdd",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:    "add",
+				Path:  "/body/[card1]",
+				Value: rawMessage(`{"id":"card4","value":"ooooo"}`),
+			},
+		},
+		Ts:  now.Add(75 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "6gdva96nqsdd",
+		Mid: "50reifj9hyt-6gdva96nqsdd",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:    "add",
+				Path:  "/body/0",
+				Value: rawMessage(`{"id":"card5","value":"gggggg"}`),
+			},
+		},
+		Ts:  now.Add(80 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "7gdva96nqsdd",
+		Mid: "50reifj9hyt-7gdva96nqsdd",
+	})
+	assert.Nil(t, err)
+	err = doc.ApplyChanges(Changes{
+		Diff: []Operation{
+			{
+				Op:   "remove",
+				Path: "/body/2",
+			},
+		},
+		Ts:  now.Add(85 * time.Second).UnixMilli(),
+		Cid: "50reifj9hyt",
+		Gid: "8gdva96nqsdd",
+		Mid: "50reifj9hyt-8gdva96nqsdd",
+	})
+	assert.Nil(t, err)
+
+	assert.Nil(t, doc.ReduceHistory(2000))
+}
+
 func TestFastForwardChanges(t *testing.T) {
 	t.Parallel()
 

--- a/reverse.go
+++ b/reverse.go
@@ -15,6 +15,7 @@ func reverse(operations []Operation, identifiers [][]string) []Operation {
 		switch operation.Op {
 		case "add":
 			operation.Op = "remove"
+			operation.Prev = nil
 
 			// if value is a object
 			id := findID(*operation.Value, identifiers)
@@ -25,10 +26,15 @@ func reverse(operations []Operation, identifiers [][]string) []Operation {
 					// replace /array/0 with /array/[objId]
 					parts[len(parts)-1] = "[" + id + "]"
 					operation.Path = strings.Join(parts, "/")
+				} else if strings.HasPrefix(parts[len(parts)-1], "[") && strings.HasSuffix(parts[len(parts)-1], "]") {
+					// replace /array/[insertBeforeThisId] with /array/[objId]
+					parts[len(parts)-1] = "[" + id + "]"
+					operation.Path = strings.Join(parts, "/")
 				}
 			}
 		case "remove":
 			operation.Op = "add"
+			operation.Value = nil
 
 			parts := strings.Split(operation.Path, "/")
 			if strings.HasPrefix(parts[len(parts)-1], "[") && strings.HasSuffix(parts[len(parts)-1], "]") {

--- a/reverse_test.go
+++ b/reverse_test.go
@@ -89,6 +89,32 @@ func TestReverse(t *testing.T) {
 			}},
 		},
 		{
+			operations: []Operation{{
+				Op:    "add",
+				Path:  "/cards/[463]",
+				Value: rawMessage(`{"id": 345, "name": "card2", "value": 2}`),
+				Prev:  rawMessage(`"bad prev"`),
+			}},
+			expected: []Operation{{
+				Op:   "remove",
+				Path: "/cards/[345]",
+				Prev: rawMessage(`{"id": 345, "name": "card2", "value": 2}`),
+			}},
+		},
+		{
+			operations: []Operation{{
+				Op:    "add",
+				Path:  "/dashboard/[534345-3435345]/cards/[463]",
+				Value: rawMessage(`{"id": 345, "name": "card2", "value": 2}`),
+				Prev:  rawMessage(`"bad prev"`),
+			}},
+			expected: []Operation{{
+				Op:   "remove",
+				Path: "/dashboard/[534345-3435345]/cards/[345]",
+				Prev: rawMessage(`{"id": 345, "name": "card2", "value": 2}`),
+			}},
+		},
+		{
 			operations: []Operation{
 				{
 					Op:    "replace",


### PR DESCRIPTION
If an ADD command with an ID was used for the position, this ID was used as Delete during the reverse instead of the ID of the added object.