### PR TITLE
Remove null values at diff

### DIFF
--- a/diff_test.go
+++ b/diff_test.go
@@ -216,6 +216,7 @@ func TestDiffWithNull(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
+			t.Parallel()
 			ops, err := diff([]byte(testCase.payloadA), []byte(testCase.payloadB), [][]string{{"id"}, {"reference", "id"}})
 			assert.Nil(t, err)
 

--- a/diff_test.go
+++ b/diff_test.go
@@ -105,7 +105,7 @@ func TestComparePrimitiveSlices(t *testing.T) {
 			expectedReplace: false,
 		},
 		{
-			description:     "differnet types",
+			description:     "different types",
 			left:            []any{"1"},
 			right:           []any{2345},
 			expectedReplace: true,

--- a/diff_test.go
+++ b/diff_test.go
@@ -62,7 +62,7 @@ func TestGetID(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var value interface{}
+		var value any
 		err := json.Unmarshal([]byte(testCase.value), &value)
 		assert.Nil(t, err)
 
@@ -76,44 +76,44 @@ func TestComparePrimitiveSlices(t *testing.T) {
 
 	testCases := []struct {
 		description     string
-		left            []interface{}
-		right           []interface{}
+		left            []any
+		right           []any
 		expectedReplace bool
 	}{
 		{
 			description:     "empty slice",
-			left:            []interface{}{},
-			right:           []interface{}{},
+			left:            []any{},
+			right:           []any{},
 			expectedReplace: false,
 		},
 		{
 			description:     "different length",
-			left:            []interface{}{"1"},
-			right:           []interface{}{"1", "2"},
+			left:            []any{"1"},
+			right:           []any{"1", "2"},
 			expectedReplace: true,
 		},
 		{
 			description:     "different values",
-			left:            []interface{}{"1"},
-			right:           []interface{}{"2"},
+			left:            []any{"1"},
+			right:           []any{"2"},
 			expectedReplace: true,
 		},
 		{
 			description:     "same length and values",
-			left:            []interface{}{"1"},
-			right:           []interface{}{"1"},
+			left:            []any{"1"},
+			right:           []any{"1"},
 			expectedReplace: false,
 		},
 		{
 			description:     "differnet types",
-			left:            []interface{}{"1"},
-			right:           []interface{}{2345},
+			left:            []any{"1"},
+			right:           []any{2345},
 			expectedReplace: true,
 		},
 		{
 			description:     "new slice is not primitive",
-			left:            []interface{}{"1"},
-			right:           []interface{}{[]string{"1"}},
+			left:            []any{"1"},
+			right:           []any{[]string{"1"}},
 			expectedReplace: true,
 		},
 	}
@@ -147,4 +147,80 @@ func TestDiffWithBadPayloads(t *testing.T) {
 	ops, err = diff([]byte("[]"), []byte("bad"), [][]string{})
 	assert.Nil(t, ops)
 	assert.Error(t, err)
+}
+
+func TestDiffWithNull(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		description string
+		payloadA    string
+		payloadB    string
+		expected    string
+	}{
+		{
+			description: "null values in right should be removed, not added",
+			payloadA:    `{"b": {"b1": "value", "c1": "test"}, "c": "test"}`,
+			payloadB:    `{"a": null, "b": {"a1": null, "b1": "value", "c1": null}, "c": null}`,
+			expected:    `[{"op":"remove","path":"/b/c1","_prev":"test"},{"op":"remove","path":"/c","_prev":"test"}]`,
+		},
+		{
+			description: "new null key should not create add operation",
+			payloadA:    `{"a": "value"}`,
+			payloadB:    `{"a": "value", "b": null}`,
+			expected:    `[]`,
+		},
+		{
+			description: "existing value to null should create remove",
+			payloadA:    `{"a": "value"}`,
+			payloadB:    `{"a": null}`,
+			expected:    `[{"op":"remove","path":"/a","_prev":"value"}]`,
+		},
+		{
+			description: "null to value should create add",
+			payloadA:    `{"a": null}`,
+			payloadB:    `{"a": "value"}`,
+			expected:    `[{"op":"add","path":"/a","value":"value"}]`,
+		},
+		{
+			description: "null to null should not create any operation",
+			payloadA:    `{"a": null}`,
+			payloadB:    `{"a": null}`,
+			expected:    `[]`,
+		},
+		{
+			description: "deeply nested null values",
+			payloadA:    `{"a": {"b": {"c": "value"}}}`,
+			payloadB:    `{"a": {"b": {"c": null, "d": null}}}`,
+			expected:    `[{"op":"remove","path":"/a/b/c","_prev":"value"}]`,
+		},
+		{
+			description: "empty objects remain unchanged",
+			payloadA:    `{}`,
+			payloadB:    `{"a": null}`,
+			expected:    `[]`,
+		},
+		{
+			description: "multiple null keys should all be ignored",
+			payloadA:    `{}`,
+			payloadB:    `{"a": null, "b": null, "c": null}`,
+			expected:    `[]`,
+		},
+		{
+			description: "mix of null and real values",
+			payloadA:    `{"existing": "old"}`,
+			payloadB:    `{"existing": "new", "null_key": null, "new_key": "value"}`,
+			expected:    `[{"op":"replace","path":"/existing","value":"new","_prev":"old"},{"op":"add","path":"/new_key","value":"value"}]`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			ops, err := diff([]byte(testCase.payloadA), []byte(testCase.payloadB), [][]string{{"id"}, {"reference", "id"}})
+			assert.Nil(t, err)
+
+			b, _ := json.Marshal(ops)
+			assert.Equal(t, testCase.expected, string(b), testCase.description)
+		})
+	}
 }


### PR DESCRIPTION
When diffing, null values are removed but new ones are also added by add. This pull request introduces a consistent line and they are always removed.